### PR TITLE
Skia: Fix path to OpenGL Headers

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -595,7 +595,7 @@ LOCAL_C_INCLUDES := \
 	external/giflib \
 	external/jpeg \
 	external/webp/include \
-	frameworks/base/opengl/include \
+	frameworks/native/opengl/include \
 	external/expat/lib
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := \


### PR DESCRIPTION
PS2: make it depending on nothing
This patch will change the path to point to the correct location
of the OpenGL Headers. The path has changed to
frameworks/native/opengl/include/.
from here:  https://github.com/VanirAOSP/external_skia/commit/1aee72f789b38fa202d3ec19afc793cc94f163e7
